### PR TITLE
Replace missing repeat function in java

### DIFF
--- a/jvm/machine/src/main/java/org/mmadt/language/console/Console.java
+++ b/jvm/machine/src/main/java/org/mmadt/language/console/Console.java
@@ -40,6 +40,9 @@ import scala.collection.JavaConverters;
 
 import javax.script.ScriptEngineManager;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
@@ -85,7 +88,7 @@ public class Console {
             try {
                 String line = reader.readLine(engineName + "> ");
                 while (line.trim().endsWith("/")) {
-                    line = line.trim().substring(0, line.length() - 1) + reader.readLine(".".repeat(engineName.length()) + "> ");
+                    line = line.trim().substring(0, line.length() - 1) + reader.readLine(IntStream.range(0, engineName.length()).mapToObj(x -> ".").collect(Collectors.joining()) + "> ");
                 }
                 ///////////////////
                 if (line.equals(QUIT_OP))


### PR DESCRIPTION
There was another missing `String.repeat` in the java code. Maybe it is the JDK? 

```
openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)
```

I replaced the single occurrence of the `repeat` function. 