### PR TITLE
Hooked in custom mm-adt specific sbt-site plugin

### DIFF
--- a/jvm/README.md
+++ b/jvm/README.md
@@ -1,0 +1,38 @@
+## Building Documentation
+
+Documentation for mm-ADT is generated through Asciidoc. To enhance the formatting of mm-ADT examples a custom syntax highlighter was developed to plug into Asciidoc infrastructure. As a result, it is necessary to have custom builds of three components which produce mm-ADT specific artifacts. The forks of these repositories can be found here:
+
+* [Coderay](https://github.com/mm-adt/coderay)
+* [Asciidoctorj](https://github.com/mm-adt/asciidoctorj)
+* [sbt-site](https://github.com/mm-adt/sbt-site)
+
+The mm-ADT project does not publish these artifacts, therefore, those wishing to build mm-ADT documentation must build them locally so that the artifacts are present in that environment. Unfortunately, these three projects are based on three different development ecosystems (Scala, Gradle, and Ruby) so the environmental prerequisites are a bit heavy handed:
+
+* Java
+* [Bundler](https://bundler.io/)
+* [sbt](https://www.scala-sbt.org/)
+* Clone the three repositories listed above
+
+Each of the forked repositories has a branch based on a specific version of its respective project that is known to work together with the other components. For each fork, checkout the appropriate branch:
+
+```bash
+coderay$ git checkout 1.1.0-mmadt
+asciidoctorj$ git checkout 1.6.2-mmadt
+sbt-site$ git checkout 1.4.0-mmadt
+```
+
+Build each of these projects with the following commands:
+
+```bash
+coderay$ bundle exec rake clean install:local
+asciidoctorj$ ./gradlew clean publishToMavenLocal -Pskip.signing
+sbt-site$ clean sbt publishLocal
+```
+
+The above commands will install each of these components to their respective local repositories so that they can each reference each other via their build tooling. If all of this publishing completed successfully, then it should be possible to generate the documentation:
+
+```text
+sbt:vm> previewSite
+```
+
+Maintaining these forks should not be overly burdensome given the lightweight nature of the changes in each repository. Ideally, tagged versions in the parent repositories should be used as bases for new branches in each of their respective forks. Versions should be aligned carefully to ensure that the dependency version of the tag matches the ones of the branches. So, if Asciidoctorj 2.0.0 uses Coderay 1.5.0, then branches should be created for `2.0.0-mmadt` in the Asciidoctorj fork and `1.5.0-mmadt` in the Coderay fork. At that point, the mm-ADT specific changes could be cherry-picked to those new mm-ADT branches.

--- a/jvm/build.sbt
+++ b/jvm/build.sbt
@@ -23,7 +23,6 @@ lazy val machine = (project in file("machine"))
       "org.jline" % "jline" % "3.13.3",
       "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2",
       // tests
-      "org.asciidoctor" % "asciidoctorj" % "2.1.0" % "test",
       "org.scalatest" %% "scalatest" % "3.0.8" % "test"),
     git.remoteRepo := scmInfo.value.get.connection.replace("scm:git:",""),
     scmInfo := Some(ScmInfo(url("https://github.com/mm-adt/vm"),"scm:git:git@github.com:mm-adt/vm.git")),

--- a/jvm/machine/src/asciidoctor/index.adoc
+++ b/jvm/machine/src/asciidoctor/index.adoc
@@ -8,7 +8,7 @@ Marko A. Rodriguez <marko@rredux.com>
 :docinfo: shared-head
 :stem: latexmath
 :source-highlighter: coderay
-:source-language: Delphi
+:source-language: mmadt
 :favicon: ./images/favicon.ico
 // :stylesdir: ./css
 // :stylesheet: mmadt.css

--- a/jvm/machine/src/asciidoctor/introduction.adoc
+++ b/jvm/machine/src/asciidoctor/introduction.adoc
@@ -54,7 +54,7 @@ mmlang>
 A simple console session is presented below, where the parser expects programs written in the language specified left
 of the `>` prompt. All the examples contained herein are presented using `mmlang`.
 
-[source]
+[source,mmadt]
 ----
 mmlang> 1
 ==>1

--- a/jvm/project/plugins.sbt
+++ b/jvm/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
+resolvers += Resolver.mavenLocal
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0-mmadt")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")


### PR DESCRIPTION
Yields some custom mm-adt code example stylings.