### PR TITLE
Added a common base test for *InstTest

### DIFF
--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/BaseInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/BaseInstTest.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
+
+package org.mmadt.processor.inst
+
+import org.mmadt.language.jsr223.mmADTScriptEngine
+import org.mmadt.language.mmlang.mmlangScriptEngineFactory
+import org.mmadt.language.obj.value.StrValue
+import org.mmadt.storage.StorageFactory._
+import org.mmadt.language.obj.value.strm.Strm
+import org.mmadt.language.obj.{Inst, Obj}
+import org.mmadt.storage.StorageFactory.{asType, zeroObj}
+import org.scalatest.FunSuite
+import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
+
+abstract class BaseInstTest extends FunSuite with TableDrivenPropertyChecks {
+  private val engine: mmADTScriptEngine = new mmlangScriptEngineFactory().getScriptEngine
+
+  def name: String
+  def starts: TableFor3[Obj, Obj, Obj]
+
+  test(name) {
+    var lastComment:String = ""
+
+    forEvery(starts) { (lhs, rhs, result) =>
+      // ignore comment lines - with comments as "data" it's easier to track which line in the table
+      // has failing data
+      if (lhs != null && rhs != null && !result.isInstanceOf[StrValue]) {
+        evaluate(lhs, rhs, result, lastComment)
+      } else {
+        lastComment = result.toString
+      }
+    }
+  }
+
+  def comment(comment: String): (Obj, Obj, Obj) = {
+    Tuple3(null, null, str(comment))
+  }
+
+  def stringify(obj: Obj): String = if (obj.isInstanceOf[Strm[_]]) {
+    if (!obj.alive)
+      zeroObj.toString
+    else
+      obj.toStrm.values.foldLeft("[")((a, b) => a.concat(b + ",")).dropRight(1).concat("]")
+  } else obj.toString
+
+  def evaluate(start: Obj, middle: Obj, end: Obj, lastComment:String = "", inst: Inst[Obj, Obj] = null,
+               engine: mmADTScriptEngine = engine, compile: Boolean = true): Unit = {
+    engine.eval(":")
+    val evaluating = List[Obj => Obj](
+      s => engine.eval(s"${stringify(s)} => ${middle}"),
+      s => s.compute(middle),
+      s => s ==> middle,
+      s => s `=>` middle,
+    )
+    val compiling = List[Obj => Obj](
+      s => (asType(s.rangeObj) ==> middle).trace.foldLeft(s)((a, b) => b._2.exec(a)),
+      s => middle.trace.foldLeft(s)((a, b) => b._2.exec(a)),
+      s => s `=>` (start.range ==> middle),
+      s => s ==> (start.range ==> middle),
+      s => s `=>` (middle.domain ==> middle),
+      s => s ==> (middle.domain ==> middle),
+      s => s `=>` (asType(start.rangeObj) ==> middle),
+      s => s ==> (asType(start.rangeObj) ==> middle))
+    val instructioning = List[Obj => Obj](s => inst.exec(s))
+    (evaluating ++
+      (if (compile) compiling else Nil) ++
+      (if (null != inst) instructioning else Nil))
+      .foreach(example => assertResult(end, lastComment)(example(start)))
+  }
+}

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
@@ -22,71 +22,66 @@
 
 package org.mmadt.processor.inst.map
 
-import org.mmadt.TestUtil
 import org.mmadt.language.LanguageException
 import org.mmadt.language.obj.Obj
 import org.mmadt.language.obj.`type`.__
 import org.mmadt.language.obj.op.map.GtOp
+import org.mmadt.processor.inst.BaseInstTest
 import org.mmadt.storage.StorageFactory._
-import org.scalatest.FunSuite
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
+import org.scalatest.prop.TableFor3
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-class GtInstTest extends FunSuite with TableDrivenPropertyChecks {
+class GtInstTest extends BaseInstTest {
+  override lazy val name = "[gt] value, type, strm, anon combinations"
 
-  test("[gt] value, type, strm, anon combinations") {
-    val starts: TableFor3[Obj, Obj, String] =
-      new TableFor3[Obj, Obj, String](("query", "result", "type"),
-        //////// INT
-        (int(2).gt(1), btrue, "value"), // value * value = value
-        (int(2).q(10).gt(1), btrue.q(10), "value"), // value * value = value
-        (int(2).q(10).gt(1).q(20), btrue.q(200), "value"), // value * value = value
-        (int(2).gt(int(1).q(10)), btrue, "value"), // value * value = value
-        (int(2).gt(int), bfalse, "value"), // value * type = value
-        (int(2).gt(__.mult(int)), bfalse, "value"), // value * anon = value
-        (int.gt(int(2)), int.gt(int(2)), "type"), // type * value = type
-        (int.q(10).gt(int(2)), int.q(10).gt(int(2)), "type"), // type * value = type
-        (int.gt(int), int.gt(int), "type"), // type * type = type
-        (int(1, 2, 3).gt(2), bool(false, false, true), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2).q(10)), bool(false, false, true), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10)), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10)), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10)), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50)), "strm"), // strm * value = strm
-        (int(1, 2, 3).id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50)), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50)), "strm"), // strm * value = strm
-        (int(1, 2, 3).gt(int), bool(false, false, false), "strm"), // strm * type = strm
-        (int(1, 2, 3).gt(__.mult(int)), bool(false, false, false), "strm"), // strm * anon = strm
-        //////// REAL
-        (real(2.0).gt(1.0), btrue, "value"), // value * value = value
-        (real(2.0).gt(real), bfalse, "value"), // value * type = value
-        (real(2.0).gt(__.mult(real)), false, "value"), // value * anon = value
-        (real.gt(real(2.0)), real.gt(2.0), "type"), // type * value = type
-        (real.gt(real), real.gt(real), "type"), // type * type = type
-        (real(1.0, 2.0, 3.0).gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3)), "strm"), // strm * value = strm
-        (real(1.0, 2.0, 3.0).gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3)), "strm"), // strm * value = strm
-        (real(1.0, 2.0, 3.0).gt(2.0), bool(false, false, true), "strm"), // strm * value = strm
-        (real(1.0, 2.0, 3.0).gt(real), bool(false, false, false), "strm"), // strm * type = strm
-        (real(1.0, 2.0, 3.0).gt(__.mult(real)), bool(false, false, false), "strm"), // strm * anon = strm
-        //////// STR
-        (str("b").gt("a"), btrue, "value"), // value * value = value
-        (str("b").q(10).gt("a"), btrue.q(10), "value"), // value * value = value
-        (str("b").q(10).gt("a").q(20), btrue.q(200), "value"), // value * value = value
-        (str("b").gt(str("a").q(10)), btrue, "value"), // value * value = value
-        (str("b").gt(str), bfalse, "value"), // value * type = value
-        (str.gt("b"), str.gt("b"), "type"), // type * value = type
-        (str.q(10).gt("b"), str.q(10).gt("b"), "type"), // type * value = type
-        (str.gt(str), str.gt(str), "type"), // type * type = type
-        (str("a", "b", "c").gt("b"), bool(false, false, true), "strm"), // strm * value = strm
-        (str("a", "b", "c").gt(str("b").q(10)), bool(false, false, true), "strm"), // strm * value = strm
-        (str("a", "b", "c") ==> __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10)), "strm"), // strm * value = strm
-        (str("a", "b", "c").gt(str), bool(false, false, false), "strm"), // strm * type = strm
+  override val starts = new TableFor3[Obj, Obj, Obj](("lhs", "rhs", "result"),
+        comment("===INT"),
+        (int(2), __.gt(1), btrue), // value * value = value
+        (int(2).q(10), __.gt(1), btrue.q(10)), // value * value = value
+        (int(2).q(10), __.gt(1).q(20), btrue.q(200)), // value * value = value
+        (int(2), __.gt(int(1).q(10)), btrue), // value * value = value
+        (int(2), __.gt(int), bfalse), // value * type = value
+        (int(2), __.gt(__.mult(int)), bfalse), // value * anon = value
+        (int, __.gt(int(2)), int.gt(int(2))), // type * value = type
+        (int.q(10), __.gt(int(2)), int.q(10).gt(int(2))), // type * value = type
+        (int, __.gt(int), int.gt(int)), // type * type = type
+        (int(1, 2, 3), __.gt(2), bool(false, false, true)), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2).q(10)), bool(false, false, true)), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10))), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+        (int(1, 2, 3), __.id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+        (int(1, 2, 3), __.gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+        (int(1, 2, 3), __.gt(int), bool(false, false, false)), // strm * type = strm
+        (int(1, 2, 3), __.gt(__.mult(int)), bool(false, false, false)), // strm * anon = strm
+        comment("===REAL"),
+        (real(2.0), __.gt(1.0), btrue), // value * value = value
+        (real(2.0), __.gt(real), bfalse), // value * type = value
+        (real(2.0), __.gt(__.mult(real)), false), // value * anon = value
+        (real, __.gt(real(2.0)), real.gt(2.0)), // type * value = type
+        (real, __.gt(real), real.gt(real)), // type * type = type
+        (real(1.0, 2.0, 3.0), __.gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+        (real(1.0, 2.0, 3.0), __.gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+        (real(1.0, 2.0, 3.0), __.gt(2.0), bool(false, false, true)), // strm * value = strm
+        (real(1.0, 2.0, 3.0), __.gt(real), bool(false, false, false)), // strm * type = strm
+        (real(1.0, 2.0, 3.0), __.gt(__.mult(real)), bool(false, false, false)), // strm * anon = strm
+        comment("===STR"),
+        (str("b"), __.gt("a"), btrue), // value * value = value
+        (str("b").q(10), __.gt("a"), btrue.q(10)), // value * value = value
+        (str("b").q(10), __.gt("a").q(20), btrue.q(200)), // value * value = value
+        (str("b"), __.gt(str("a").q(10)), btrue), // value * value = value
+        (str("b"), __.gt(str), bfalse), // value * type = value
+        (str, __.gt("b"), str.gt("b")), // type * value = type
+        (str.q(10), __.gt("b"), str.q(10).gt("b")), // type * value = type
+        (str, __.gt(str), str.gt(str)), // type * type = type
+        (str("a", "b", "c"), __.gt("b"), bool(false, false, true)), // strm * value = strm
+        (str("a", "b", "c"), __.gt(str("b").q(10)), bool(false, false, true)), // strm * value = strm
+        (str("a", "b", "c"), __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+        (str("a", "b", "c"), __.gt(str), bool(false, false, false)) // strm * type = strm
       )
-    forEvery(starts) { (query, result, _) => TestUtil.evaluate(query, __, result)
-    }
-  }
 
   test("[gt] exceptions") {
     assertResult(LanguageException.unsupportedInstType(bfalse, GtOp(btrue)).getMessage)(intercept[LanguageException](bfalse ==> __.gt(btrue)).getMessage)


### PR DESCRIPTION
The base test drags eliminates the TestUtil and makes it so that implementing tests only need to extend it and add a "name" for the test and the Table3 data. This base class  also provides for a comment() which can be used as 

1.  a header for sections and 
2. to help locate the line of data in the table that has some failure as the "last comment" is printed on failure of an assertion. Also note that by convention, test data should start on a zero line in the code so that the math remains simple to find the failing line since scalatest does output the line number of the table that failed.

As an example:

```
tableDrivenForEveryFailed:   org.scalatest.exceptions.TableDrivenPropertyCheckFailedException: TestFailedException was thrown during property evaluation. (BaseInstTest.scala:22)
    Message: Expected true, but got false '===REAL'
    Location: (BaseInstTest.scala:65)
    Occurred at table row 21 (zero based, not counting headings), which had values (
    lhs = 2.0
    rhs = _[gt,3.0]
    result = true  )
```

Note the output of "===REAL" which is a "sub-heading" comment in the test data at:

https://github.com/mm-adt/vm/compare/master...spmallette:test-pattern-refactor?expand=1#diff-035da6517898b4ca9a1cc7228485e0bdR60

and the table line failure is easily calculated by adding "row 21" to the starting row at 40 which puts the failure at 61. 