### PR TITLE
Added test sets

### DIFF
--- a/jvm/machine/src/main/scala/org/mmadt/language/obj/op/branch/BranchOp.scala
+++ b/jvm/machine/src/main/scala/org/mmadt/language/obj/op/branch/BranchOp.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.language.obj.op.branch
 
 import org.mmadt.language.Tokens

--- a/jvm/machine/src/main/scala/org/mmadt/language/obj/op/reduce/SumOp.scala
+++ b/jvm/machine/src/main/scala/org/mmadt/language/obj/op/reduce/SumOp.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.language.obj.op.reduce
 
 import org.mmadt.language.Tokens

--- a/jvm/machine/src/main/scala/org/mmadt/language/obj/op/trace/ModelOp.scala
+++ b/jvm/machine/src/main/scala/org/mmadt/language/obj/op/trace/ModelOp.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.language.obj.op.trace
 
 import org.mmadt.language.Tokens

--- a/jvm/machine/src/test/scala/org/mmadt/TestUtil.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/TestUtil.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt
 
 import org.mmadt.language.jsr223.mmADTScriptEngine

--- a/jvm/machine/src/test/scala/org/mmadt/language/model/mmTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/language/model/mmTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.language.model
 
 import org.mmadt.storage.StorageFactory._

--- a/jvm/machine/src/test/scala/org/mmadt/language/obj/value/RecValueTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/language/obj/value/RecValueTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.language.obj.value
 
 import org.mmadt.language.Tokens

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/TestSetUtil.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/TestSetUtil.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
+
+package org.mmadt.processor.inst
+
+import org.mmadt.language.obj.Obj
+import org.mmadt.storage.StorageFactory.str
+import org.scalatest.prop.TableFor4
+
+object TestSetUtil {
+
+  def testSet(testName: String, data:(Obj, Obj, Obj, Boolean)*): (String, TableFor4[Obj, Obj, Obj, Boolean]) =
+    (testName, new TableFor4[Obj, Obj, Obj, Boolean](("lhs", "rhs", "result", "compile"), data: _*))
+
+  def test(lhs: Obj, rhs: Obj, result: Obj, compile: Boolean = true): (Obj, Obj, Obj, Boolean) = (lhs, rhs, result, compile)
+
+  def comment(comment: String): (Obj, Obj, Obj, Boolean) = (null, null, str(comment), false)
+}

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/BranchTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/BranchTest.scala
@@ -1,113 +1,83 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
+
 package org.mmadt.processor.inst.branch
 
-import org.mmadt.TestUtil
 import org.mmadt.language.obj.`type`.__
 import org.mmadt.language.obj.op.map.PlusOp
-import org.mmadt.language.obj.{Int, Obj}
+import org.mmadt.language.obj.Obj
+import org.mmadt.processor.inst.BaseInstTest
+import org.mmadt.processor.inst.TestSetUtil.{test, testSet}
 import org.mmadt.storage.StorageFactory._
-import org.scalatest.FunSuite
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-class BranchTest extends FunSuite with TableDrivenPropertyChecks {
-
-
-  test("[branch] ,-lst") {
-    val starts: TableFor3[Obj, Obj, Obj] =
-      new TableFor3[Obj, Obj, Obj](("start", "middle", "end"),
-        (int.q(10), __.plus(0).branch(__.plus(1) `,` __.plus(2)).is(__.gt(10)), int.q(0, 20) <= int.q(10).plus(0).branch(__.plus(1) `,` __.plus(2)).is(__.gt(10))),
-        (int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2)), int(2, 3)),
-        (int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2) `,` int.plus(3)), int(2, 3, 4)),
-        (int(1), int.plus(0).branch(__.plus(1).q(2) `,` __.plus(2).q(3) `,` int.plus(3).q(4)), int(int(2).q(2), int(3).q(3), int(4).q(4))),
-        (int(1), int.plus(0).branch(__.plus(1).plus(1) `,` __.plus(2)), int(3).q(2)),
-        (int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) `,` __.plus(2)), int(int(3).q(2), int(4).q(2))),
-        (int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2)).path(), strm(List(lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), 3)))))),
-        /*(int(1, 2), int.q(2).plus(0).branch[Int](__.plus(1) `,` __.plus(2)).path(), strm(List(
-          lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
-          lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), int(3).q(2)))), // TODO: <-- q(2)
-          // lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3))), // TODO: WHEN USING PATH, UNIQUNESS BASED ON OBJ GRAPH PATH!
-          lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(2), 4)))))),*/
-      )
-    forEvery(starts) { (start, middle, end) => TestUtil.evaluate(start, middle, end)
-    }
-  }
-
-  test("[branch] ;-lst") {
-    val starts: TableFor3[Obj, Obj, Obj] =
-      new TableFor3[Obj, Obj, Obj](("start", "middle", "end"),
-        (int.q(10), __.plus(0).branch(__.plus(1) `;` __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(__.plus(1) `;` __.plus(2)).is(__.gt(10))),
-        (int(1), int.plus(0).branch(__.plus(1) `;` __.plus(2)), int(4)),
-        (int(1), int.plus(0).branch(__.plus(1) `;` __.plus(2) `;` int.plus(3)), int(7)),
-        (int(1), int.plus(0).branch(__.plus(1).q(2) `;` __.plus(2).q(3) `;` int.plus(3).q(4)), int(7).q(24)),
-        (int(1), int.plus(0).branch(__.plus(1).plus(1) `;` __.plus(2)), int(5)),
-        (int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) `;` __.plus(2)), int(5, 6)),
-        //(int(1), int.plus(0).branch[Int](__.plus(1) `;` __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2, PlusOp(2),4)))), // TODO: TYPES IN A STRM
-        (int(1, 2), int.q(2).plus(0).branch(__.plus(1) `;` __.plus(2)).path(), strm(List(
-          lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2, PlusOp(2), 4))),
-          lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3, PlusOp(2), 5)))))),
-      )
-    forEvery(starts) { (start, middle, end) => TestUtil.evaluate(start, middle, end)
-    }
-  }
-
-  test("[branch] |-lst") {
-    val starts: TableFor3[Obj, Obj, Obj] =
-      new TableFor3[Obj, Obj, Obj](("start", "middle", "end"),
-        (int.q(10), __.plus(0).branch(__.plus(1) | __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(__.plus(1) | __.plus(2)).is(__.gt(10))),
-        (int(1), int.plus(0).branch(__.plus(1) | __.plus(2)), int(2)),
-        (int(1), int.plus(0).branch(__.plus(1).q(0) | __.plus(2) | int.plus(3)), int(3)),
-        (int(1), int.plus(0).branch(__.plus(1).q(0) | __.plus(2).q(0) | int.plus(3)), int(4)),
-        // (int(1), int.plus(0).branch(__.plus(1).q(2) | __.plus(2).q(3) | int.plus(3).q(4)), int(2).q(2)), // TODO: VALUE QUANTIFIERS ARE NOT RANGED
-        (int(1), int.plus(0).branch(__.plus(1).plus(1) | __.plus(3)), int(3)),
-        (int(1), int.plus(0).branch(__.plus(1).q(0).plus(1) | __.plus(3)), int(4)),
-        (int(1), int.plus(0).branch(__.plus(1).plus(1).q(0) | __.plus(3)), int(4)),
-        (int(1), int.plus(0).branch(__.plus(1).plus(1).q(0) | __.plus(3).q(0)), zeroObj),
-        (int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) | __.plus(2)), int(3, 4)),
-        //(int(1), int.plus(0).branch[Int](__.plus(1) | __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2)))), // TODO: TYPES IN A STRM
-        (int(1, 2), int.q(2).plus(0).branch(__.plus(1) | __.plus(2)).path(), strm(List(
-          lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
-          lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3)))))),
-      )
-    forEvery(starts) { (start, middle, end) => TestUtil.evaluate(start, middle, end, compile = false)
-    }
-  }
-
-  //////////////////
-
-  test("[branch] ,-rec") {
-    val starts: TableFor3[Int, Obj, Obj] =
-      new TableFor3[Int, Obj, Obj](("start", "middle", "end"),
-        (int(0), __.plus(1).branch((__.is(__.gt(1)) -> __.plus(10)) `_,` (__.is(__.gt(2)) -> __.plus(20)) `_,` (__ -> int.plus(30))), int(31)),
-        (int(1, 2, 3), __.plus(0).branch((__.is(__.gt(1)) -> __.plus(10)) `_,` (__.is(__.gt(2)) -> __.plus(20)) `_,` (__ -> int.plus(30))), int(31, 12, 13, 32, 23, 33)),
-      )
-    forEvery(starts) { (start, middle, end) => TestUtil.evaluate(start, middle, end)
-    }
-  }
-
-  test("[branch] |-rec") {
-    val starts: TableFor3[Int, Obj, Obj] =
-      new TableFor3[Int, Obj, Obj](("start", "middle", "end"),
-        (int.q(10), __.plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).is(__.gt(10))),
-        (int(1), int.plus(0).branch((int + 0 -> int.plus(1)) `_|` (int -> int.plus(2))), int(2)),
-        //(int(1), int.plus(0).branch((int.q(0) -> int.plus(1)) `|` (int + 0 -> int.plus(2)) `|` (int -> int.plus(3))), int(3)),
-        (int(1), int.plus(0).branch(int.q(0) -> __.plus(1) `_|` int.q(0) -> __.plus(2) `_|` int + 0 -> int.plus(3)), int(4)),
-        // (int(1), int.plus(0).branch(__.plus(1).q(2) | __.plus(2).q(3) | int.plus(3).q(4)), int(2).q(2)), // TODO: VALUE QUANTIFIERS ARE NOT RANGED
-        (int(1), int.plus(0).branch(int + 0 -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(3)),
-        // (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(4)),
-        // (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(4)),
-        (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3).q(0)), zeroObj),
-        (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int.plus(1).q(0) -> __.plus(3)), zeroObj),
-        (int(1, 2), int.q(2).plus(0).branch(int + 0 -> __.plus(1).plus(1) `_|` int -> __.plus(2)), int(3, 4)),
-        //(int(1), int.plus(0).branch[Int](__.plus(1) | __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2)))), // TODO: TYPES IN A STRM
-        (int(1, 2), int.q(2).plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).path(), strm(List(
-          lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
-          lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3)))))),
-      )
-    forEvery(starts) { (start, middle, end) => TestUtil.evaluate(start, middle, end, compile = false)
-    }
-  }
+class BranchTest extends BaseInstTest(
+  testSet("[branch] ,-lst",
+    test(int.q(10), __.plus(0).branch(__.plus(1) `,` __.plus(2)).is(__.gt(10)), int.q(0, 20) <= int.q(10).plus(0).branch(__.plus(1) `,` __.plus(2)).is(__.gt(10))),
+    test(int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2)), int(2, 3)),
+    test(int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2) `,` int.plus(3)), int(2, 3, 4)),
+    test(int(1), int.plus(0).branch(__.plus(1).q(2) `,` __.plus(2).q(3) `,` int.plus(3).q(4)), int(int(2).q(2), int(3).q(3), int(4).q(4))),
+    test(int(1), int.plus(0).branch(__.plus(1).plus(1) `,` __.plus(2)), int(3).q(2)),
+    test(int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) `,` __.plus(2)), int(int(3).q(2), int(4).q(2))),
+    test(int(1), int.plus(0).branch(__.plus(1) `,` __.plus(2)).path(), strm(List(lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), 3))))))),
+  testSet("[branch] ;-lst",
+    test(int.q(10), __.plus(0).branch(__.plus(1) `;` __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(__.plus(1) `;` __.plus(2)).is(__.gt(10))),
+    test(int(1), int.plus(0).branch(__.plus(1) `;` __.plus(2)), int(4)),
+    test(int(1), int.plus(0).branch(__.plus(1) `;` __.plus(2) `;` int.plus(3)), int(7)),
+    test(int(1), int.plus(0).branch(__.plus(1).q(2) `;` __.plus(2).q(3) `;` int.plus(3).q(4)), int(7).q(24)),
+    test(int(1), int.plus(0).branch(__.plus(1).plus(1) `;` __.plus(2)), int(5)),
+    test(int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) `;` __.plus(2)), int(5, 6)),
+    test(int(1, 2), int.q(2).plus(0).branch(__.plus(1) `;` __.plus(2)).path(), strm(List(
+      lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2, PlusOp(2), 4))),
+      lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3, PlusOp(2), 5))))))),
+  testSet("[branch] |-lst",
+    test(int.q(10), __.plus(0).branch(__.plus(1) | __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(__.plus(1) | __.plus(2)).is(__.gt(10))),
+    test(int(1), int.plus(0).branch(__.plus(1) | __.plus(2)), int(2)),
+    test(int(1), int.plus(0).branch(__.plus(1).q(0) | __.plus(2) | int.plus(3)), int(3)),
+    test(int(1), int.plus(0).branch(__.plus(1).q(0) | __.plus(2).q(0) | int.plus(3)), int(4)),
+    test(int(1), int.plus(0).branch(__.plus(1).plus(1) | __.plus(3)), int(3)),
+    test(int(1), int.plus(0).branch(__.plus(1).q(0).plus(1) | __.plus(3)), int(4)),
+    test(int(1), int.plus(0).branch(__.plus(1).plus(1).q(0) | __.plus(3)), int(4)),
+    test(int(1), int.plus(0).branch(__.plus(1).plus(1).q(0) | __.plus(3).q(0)), zeroObj, false),
+    test(int(1, 2), int.q(2).plus(0).branch(__.plus(1).plus(1) | __.plus(2)), int(3, 4)),
+    test(int(1, 2), int.q(2).plus(0).branch(__.plus(1) | __.plus(2)).path(), strm(List(
+      lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
+      lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3))))))),
+  testSet("[branch] ,-rec",
+    test(int(0), __.plus(1).branch((__.is(__.gt(1)) -> __.plus(10)) `_,` (__.is(__.gt(2)) -> __.plus(20)) `_,` (__ -> int.plus(30))), int(31)),
+    test(int(1, 2, 3), __.plus(0).branch((__.is(__.gt(1)) -> __.plus(10)) `_,` (__.is(__.gt(2)) -> __.plus(20)) `_,` (__ -> int.plus(30))), int(31, 12, 13, 32, 23, 33))),
+  testSet("[branch] |-rec",
+    test(int.q(10), __.plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).is(__.gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).is(__.gt(10))),
+    test(int(1), int.plus(0).branch((int + 0 -> int.plus(1)) `_|` (int -> int.plus(2))), int(2)),
+    test(int(1), int.plus(0).branch(int.q(0) -> __.plus(1) `_|` int.q(0) -> __.plus(2) `_|` int + 0 -> int.plus(3)), int(4)),
+    test(int(1), int.plus(0).branch(int + 0 -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(3)),
+    test(int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3).q(0)), zeroObj, false),
+    test(int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int.plus(1).q(0) -> __.plus(3)), zeroObj, false),
+    test(int(1, 2), int.q(2).plus(0).branch(int + 0 -> __.plus(1).plus(1) `_|` int -> __.plus(2)), int(3, 4)),
+    test(int(1, 2), int.q(2).plus(0).branch(int + 0 -> __.plus(1) `_|` int -> __.plus(2)).path(), strm(List(
+      lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
+      lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3)))))))) {
 
   test("[branch] path testing") {
     assertResult("(5;[plus,0];5;[plus,1];6;[plus,3];9)")(int(5).plus(0).branch(int.plus(1) `,` int.plus(2)).plus(3).path().toStrm.values(0).toString)
@@ -119,5 +89,19 @@ class BranchTest extends FunSuite with TableDrivenPropertyChecks {
     assertResult("(5;[plus,0];5;[plus,1];6;[plus,11];17;[plus,3];20)")(int(5).plus(0).branch(int.plus(1).plus(11) `,` int.plus(2)).plus(3).path().toStrm.values(0).toString)
     assertResult("(5;[plus,0];5;[plus,2];7;[plus,3];10)")(int(5).plus(0).branch(int.plus(1).plus(11) `,` int.plus(2)).plus(3).path().toStrm.values(1).toString)
   }
+
+  /*(int(1, 2), int.q(2).plus(0).branch[Int](__.plus(1) `,` __.plus(2)).path(), strm(List(
+  lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
+  lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), int(3).q(2)))), // TODO: <-- q(2)
+  // lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3))), // TODO: WHEN USING PATH, UNIQUNESS BASED ON OBJ GRAPH PATH!
+  lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(2), 4)))))),*/
+  //(int(1), int.plus(0).branch[Int](__.plus(1) `;` __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2, PlusOp(2),4)))), // TODO: TYPES IN A STRM
+  // (int(1), int.plus(0).branch(__.plus(1).q(2) | __.plus(2).q(3) | int.plus(3).q(4)), int(2).q(2)), // TODO: VALUE QUANTIFIERS ARE NOT RANGED
+  //(int(1), int.plus(0).branch[Int](__.plus(1) | __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2)))), // TODO: TYPES IN A STRM
+  //(int(1), int.plus(0).branch((int.q(0) -> int.plus(1)) `|` (int + 0 -> int.plus(2)) `|` (int -> int.plus(3))), int(3)),
+  // (int(1), int.plus(0).branch(__.plus(1).q(2) | __.plus(2).q(3) | int.plus(3).q(4)), int(2).q(2)), // TODO: VALUE QUANTIFIERS ARE NOT RANGED
+  // (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(4)),
+  // (int(1), int.plus(0).branch(int.q(0) -> __.plus(1).plus(1) `_|` int -> __.plus(3)), int(4)),
+  //(int(1), int.plus(0).branch[Int](__.plus(1) | __.plus(2)).path(), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2)))), // TODO: TYPES IN A STRM
 
 }

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
@@ -23,65 +23,63 @@
 package org.mmadt.processor.inst.map
 
 import org.mmadt.language.LanguageException
-import org.mmadt.language.obj.Obj
 import org.mmadt.language.obj.`type`.__
 import org.mmadt.language.obj.op.map.GtOp
 import org.mmadt.processor.inst.BaseInstTest
+import org.mmadt.processor.inst.TestSetUtil._
 import org.mmadt.storage.StorageFactory._
-import org.scalatest.prop.TableFor3
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
-class GtInstTest extends BaseInstTest {
-  override lazy val name = "[gt] value, type, strm, anon combinations"
-
-  override val starts = new TableFor3[Obj, Obj, Obj](("lhs", "rhs", "result"),
-        comment("===INT"),
-        (int(2), __.gt(1), btrue), // value * value = value
-        (int(2).q(10), __.gt(1), btrue.q(10)), // value * value = value
-        (int(2).q(10), __.gt(1).q(20), btrue.q(200)), // value * value = value
-        (int(2), __.gt(int(1).q(10)), btrue), // value * value = value
-        (int(2), __.gt(int), bfalse), // value * type = value
-        (int(2), __.gt(__.mult(int)), bfalse), // value * anon = value
-        (int, __.gt(int(2)), int.gt(int(2))), // type * value = type
-        (int.q(10), __.gt(int(2)), int.q(10).gt(int(2))), // type * value = type
-        (int, __.gt(int), int.gt(int)), // type * type = type
-        (int(1, 2, 3), __.gt(2), bool(false, false, true)), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2).q(10)), bool(false, false, true)), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10))), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-        (int(1, 2, 3), __.id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-        (int(1, 2, 3), __.gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-        (int(1, 2, 3), __.gt(int), bool(false, false, false)), // strm * type = strm
-        (int(1, 2, 3), __.gt(__.mult(int)), bool(false, false, false)), // strm * anon = strm
-        comment("===REAL"),
-        (real(2.0), __.gt(1.0), btrue), // value * value = value
-        (real(2.0), __.gt(real), bfalse), // value * type = value
-        (real(2.0), __.gt(__.mult(real)), false), // value * anon = value
-        (real, __.gt(real(2.0)), real.gt(2.0)), // type * value = type
-        (real, __.gt(real), real.gt(real)), // type * type = type
-        (real(1.0, 2.0, 3.0), __.gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
-        (real(1.0, 2.0, 3.0), __.gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
-        (real(1.0, 2.0, 3.0), __.gt(2.0), bool(false, false, true)), // strm * value = strm
-        (real(1.0, 2.0, 3.0), __.gt(real), bool(false, false, false)), // strm * type = strm
-        (real(1.0, 2.0, 3.0), __.gt(__.mult(real)), bool(false, false, false)), // strm * anon = strm
-        comment("===STR"),
-        (str("b"), __.gt("a"), btrue), // value * value = value
-        (str("b").q(10), __.gt("a"), btrue.q(10)), // value * value = value
-        (str("b").q(10), __.gt("a").q(20), btrue.q(200)), // value * value = value
-        (str("b"), __.gt(str("a").q(10)), btrue), // value * value = value
-        (str("b"), __.gt(str), bfalse), // value * type = value
-        (str, __.gt("b"), str.gt("b")), // type * value = type
-        (str.q(10), __.gt("b"), str.q(10).gt("b")), // type * value = type
-        (str, __.gt(str), str.gt(str)), // type * type = type
-        (str("a", "b", "c"), __.gt("b"), bool(false, false, true)), // strm * value = strm
-        (str("a", "b", "c"), __.gt(str("b").q(10)), bool(false, false, true)), // strm * value = strm
-        (str("a", "b", "c"), __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-        (str("a", "b", "c"), __.gt(str), bool(false, false, false)) // strm * type = strm
-      )
+class GtInstTest extends BaseInstTest(
+  /////////////////////////////////////////
+  testSet("[gt] value, type, strm, anon combinations",
+    comment("===INT"),
+    test(int(2), __.gt(1), btrue), // value * value = value
+    test(int(2).q(10), __.gt(1), btrue.q(10)), // value * value = value
+    test(int(2).q(10), __.gt(1).q(20), btrue.q(200)), // value * value = value
+    test(int(2), __.gt(int(1).q(10)), btrue), // value * value = value
+    test(int(2), __.gt(int), bfalse), // value * type = value
+    test(int(2), __.gt(__.mult(int)), bfalse), // value * anon = value
+    test(int, __.gt(int(2)), int.gt(int(2))), // type * value = type
+    test(int.q(10), __.gt(int(2)), int.q(10).gt(int(2))), // type * value = type
+    test(int, __.gt(int), int.gt(int)), // type * type = type
+    test(int(1, 2, 3), __.gt(2), bool(false, false, true)), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2).q(10)), bool(false, false, true)), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10))), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    test(int(1, 2, 3), __.id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    test(int(1, 2, 3), __.gt(int), bool(false, false, false)), // strm * type = strm
+    test(int(1, 2, 3), __.gt(__.mult(int)), bool(false, false, false)), // strm * anon = strm
+    comment("===REAL"),
+    test(real(2.0), __.gt(1.0), btrue), // value * value = value
+    test(real(2.0), __.gt(real), bfalse), // value * type = value
+    test(real(2.0), __.gt(__.mult(real)), false), // value * anon = value
+    test(real, __.gt(real(2.0)), real.gt(2.0)), // type * value = type
+    test(real, __.gt(real), real.gt(real)), // type * type = type
+    test(real(1.0, 2.0, 3.0), __.gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+    test(real(1.0, 2.0, 3.0), __.gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+    test(real(1.0, 2.0, 3.0), __.gt(2.0), bool(false, false, true)), // strm * value = strm
+    test(real(1.0, 2.0, 3.0), __.gt(real), bool(false, false, false)), // strm * type = strm
+    test(real(1.0, 2.0, 3.0), __.gt(__.mult(real)), bool(false, false, false)), // strm * anon = strm
+    comment("===STR"),
+    test(str("b"), __.gt("a"), btrue), // value * value = value
+    test(str("b").q(10), __.gt("a"), btrue.q(10)), // value * value = value
+    test(str("b").q(10), __.gt("a").q(20), btrue.q(200)), // value * value = value
+    test(str("b"), __.gt(str("a").q(10)), btrue), // value * value = value
+    test(str("b"), __.gt(str), bfalse), // value * type = value
+    test(str, __.gt("b"), str.gt("b")), // type * value = type
+    test(str.q(10), __.gt("b"), str.q(10).gt("b")), // type * value = type
+    test(str, __.gt(str), str.gt(str)), // type * type = type
+    test(str("a", "b", "c"), __.gt("b"), bool(false, false, true)), // strm * value = strm
+    test(str("a", "b", "c"), __.gt(str("b").q(10)), bool(false, false, true)), // strm * value = strm
+    test(str("a", "b", "c"), __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    test(str("a", "b", "c"), __.gt(str), bool(false, false, false)) // strm * type = strm
+  )) {
 
   test("[gt] exceptions") {
     assertResult(LanguageException.unsupportedInstType(bfalse, GtOp(btrue)).getMessage)(intercept[LanguageException](bfalse ==> __.gt(btrue)).getMessage)

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/reduce/SumInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/reduce/SumInstTest.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2019-2029 RReduX,Inc. [http://rredux.com]
+ *
+ * This file is part of mm-ADT.
+ *
+ * mm-ADT is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * mm-ADT is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with mm-ADT. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * You can be released from the requirements of the license by purchasing a
+ * commercial license from RReduX,Inc. at [info@rredux.com].
+ */
 package org.mmadt.processor.inst.reduce
 
 import org.mmadt.storage.StorageFactory.{*, +, int}


### PR DESCRIPTION
Provided a way to do sets of inst tests so that they organize nicely as well as an approach to providing the per test item "compile" option. I suppose that can be extended by just adding more default arguments to the `test()` function. Not sure I completely like this but got tired of fighting scala for a more elegant way. 

There is a separate commit in here to add some missing file headers. 