### PR TITLE
Converted all branch tests to use BaseInstTest

### DIFF
--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/BaseInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/BaseInstTest.scala
@@ -30,6 +30,9 @@ import org.mmadt.storage.StorageFactory.{asType, zeroObj, _}
 import org.scalatest.{FunSuite, Tag}
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3, TableFor4}
 
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
 abstract class BaseInstTest(testSets: (String, TableFor4[Obj, Obj, Obj, Boolean])*) extends FunSuite with TableDrivenPropertyChecks {
   private val engine: mmADTScriptEngine = new mmlangScriptEngineFactory().getScriptEngine
 

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/TestSetUtil.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/TestSetUtil.scala
@@ -26,12 +26,15 @@ import org.mmadt.language.obj.Obj
 import org.mmadt.storage.StorageFactory.str
 import org.scalatest.prop.TableFor4
 
+/**
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
 object TestSetUtil {
 
   def testSet(testName: String, data:(Obj, Obj, Obj, Boolean)*): (String, TableFor4[Obj, Obj, Obj, Boolean]) =
     (testName, new TableFor4[Obj, Obj, Obj, Boolean](("lhs", "rhs", "result", "compile"), data: _*))
 
-  def test(lhs: Obj, rhs: Obj, result: Obj, compile: Boolean = true): (Obj, Obj, Obj, Boolean) = (lhs, rhs, result, compile)
+  def testing(lhs: Obj, rhs: Obj, result: Obj, compile: Boolean = true): (Obj, Obj, Obj, Boolean) = (lhs, rhs, result, compile)
 
   def comment(comment: String): (Obj, Obj, Obj, Boolean) = (null, null, str(comment), false)
 }

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/BranchTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/BranchTest.scala
@@ -27,7 +27,7 @@ import org.mmadt.language.obj.`type`.__
 import org.mmadt.language.obj.`type`.__._
 import org.mmadt.language.obj.op.map.PlusOp
 import org.mmadt.processor.inst.BaseInstTest
-import org.mmadt.processor.inst.TestSetUtil.{test, testSet}
+import org.mmadt.processor.inst.TestSetUtil.{testing, testSet}
 import org.mmadt.storage.StorageFactory._
 
 /**
@@ -35,50 +35,50 @@ import org.mmadt.storage.StorageFactory._
  */
 class BranchTest extends BaseInstTest(
   testSet("[branch] ,-lst",
-    test(int.q(10), plus(0).branch(plus(1) `,` plus(2)).is(gt(10)), int.q(0, 20) <= int.q(10).plus(0).branch(plus(1) `,` plus(2)).is(gt(10))),
-    test(int(1), int.plus(0).branch(plus(1) `,` plus(2)), int(2, 3)),
-    test(int(1), int.plus(0).branch(plus(1) `,` plus(2) `,` int.plus(3)), int(2, 3, 4)),
-    test(int(1), int.plus(0).branch(plus(1).q(2) `,` plus(2).q(3) `,` int.plus(3).q(4)), int(int(2).q(2), int(3).q(3), int(4).q(4))),
-    test(int(1), int.plus(0).branch(plus(1).plus(1) `,` plus(2)), int(3).q(2)),
-    test(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) `,` plus(2)), int(int(3).q(2), int(4).q(2))),
-    test(int(1), int.plus(0).branch(plus(1) `,` plus(2)).path(), strm(lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), 3)))))),
+    testing(int.q(10), plus(0).branch(plus(1) `,` plus(2)).is(gt(10)), int.q(0, 20) <= int.q(10).plus(0).branch(plus(1) `,` plus(2)).is(gt(10))),
+    testing(int(1), int.plus(0).branch(plus(1) `,` plus(2)), int(2, 3)),
+    testing(int(1), int.plus(0).branch(plus(1) `,` plus(2) `,` int.plus(3)), int(2, 3, 4)),
+    testing(int(1), int.plus(0).branch(plus(1).q(2) `,` plus(2).q(3) `,` int.plus(3).q(4)), int(int(2).q(2), int(3).q(3), int(4).q(4))),
+    testing(int(1), int.plus(0).branch(plus(1).plus(1) `,` plus(2)), int(3).q(2)),
+    testing(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) `,` plus(2)), int(int(3).q(2), int(4).q(2))),
+    testing(int(1), int.plus(0).branch(plus(1) `,` plus(2)).path(), strm(lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))), lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(2), 3)))))),
   testSet("[branch] ;-lst",
-    test(int.q(10), plus(0).branch(plus(1) `;` plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(plus(1) `;` plus(2)).is(gt(10))),
-    test(int(1), int.plus(0).branch(plus(1) `;` plus(2)), int(4)),
-    test(int(1), int.plus(0).branch(plus(1) `;` plus(2) `;` int.plus(3)), int(7)),
-    test(int(1), int.plus(0).branch(plus(1).q(2) `;` plus(2).q(3) `;` int.plus(3).q(4)), int(7).q(24)),
-    test(int(1), int.plus(0).branch(plus(1).plus(1) `;` plus(2)), int(5)),
-    test(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) `;` plus(2)), int(5, 6)),
-    test(int(1, 2), int.q(2).plus(0).branch(plus(1) `;` plus(2)).path(), strm(
+    testing(int.q(10), plus(0).branch(plus(1) `;` plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(plus(1) `;` plus(2)).is(gt(10))),
+    testing(int(1), int.plus(0).branch(plus(1) `;` plus(2)), int(4)),
+    testing(int(1), int.plus(0).branch(plus(1) `;` plus(2) `;` int.plus(3)), int(7)),
+    testing(int(1), int.plus(0).branch(plus(1).q(2) `;` plus(2).q(3) `;` int.plus(3).q(4)), int(7).q(24)),
+    testing(int(1), int.plus(0).branch(plus(1).plus(1) `;` plus(2)), int(5)),
+    testing(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) `;` plus(2)), int(5, 6)),
+    testing(int(1, 2), int.q(2).plus(0).branch(plus(1) `;` plus(2)).path(), strm(
       lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2, PlusOp(2), 4))),
       lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3, PlusOp(2), 5)))))),
   testSet("[branch] |-lst",
-    test(int.q(10), plus(0).branch(plus(1) | plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(plus(1) | plus(2)).is(gt(10))),
-    test(int(1), int.plus(0).branch(plus(1) | plus(2)), int(2)),
-    test(int(1), int.plus(0).branch(plus(1).q(0) | plus(2) | int.plus(3)), int(3)),
-    test(int(1), int.plus(0).branch(plus(1).q(0) | plus(2).q(0) | int.plus(3)), int(4)),
-    test(int(1), int.plus(0).branch(plus(1).plus(1) | plus(3)), int(3)),
-    test(int(1), int.plus(0).branch(plus(1).q(0).plus(1) | plus(3)), int(4)),
-    test(int(1), int.plus(0).branch(plus(1).plus(1).q(0) | plus(3)), int(4)),
-    test(int(1), int.plus(0).branch(plus(1).plus(1).q(0) | plus(3).q(0)), zeroObj, compile = false),
-    test(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) | plus(2)), int(3, 4)),
-    test(int(1, 2), int.q(2).plus(0).branch(plus(1) | plus(2)).path(), strm(
+    testing(int.q(10), plus(0).branch(plus(1) | plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(plus(1) | plus(2)).is(gt(10))),
+    testing(int(1), int.plus(0).branch(plus(1) | plus(2)), int(2)),
+    testing(int(1), int.plus(0).branch(plus(1).q(0) | plus(2) | int.plus(3)), int(3)),
+    testing(int(1), int.plus(0).branch(plus(1).q(0) | plus(2).q(0) | int.plus(3)), int(4)),
+    testing(int(1), int.plus(0).branch(plus(1).plus(1) | plus(3)), int(3)),
+    testing(int(1), int.plus(0).branch(plus(1).q(0).plus(1) | plus(3)), int(4)),
+    testing(int(1), int.plus(0).branch(plus(1).plus(1).q(0) | plus(3)), int(4)),
+    testing(int(1), int.plus(0).branch(plus(1).plus(1).q(0) | plus(3).q(0)), zeroObj, compile = false),
+    testing(int(1, 2), int.q(2).plus(0).branch(plus(1).plus(1) | plus(2)), int(3, 4)),
+    testing(int(1, 2), int.q(2).plus(0).branch(plus(1) | plus(2)).path(), strm(
       lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
       lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3)))))),
   testSet("[branch] ,-rec",
-    test(int(0), plus(1).branch((is(gt(1)) -> plus(10)) `_,` (is(gt(2)) -> plus(20)) `_,` (__ -> int.plus(30))), int(31)),
-    test(int(1, 2, 3), plus(0).branch((is(gt(1)) -> plus(10)) `_,` (is(gt(2)) -> plus(20)) `_,` (__ -> int.plus(30))), int(31, 12, 13, 32, 23, 33)),
-    test(int(5), plus(0).branch(__ -> plus(1) `_,` __ -> plus(2) `_,` is(gt(10)) -> plus(6)), int(6, 7)),
-    test(int(11), plus(0).branch(__ -> plus(1) `_,` __ -> plus(2) `_,` is(gt(10)) -> plus(6)), int(12, 13,17))),
+    testing(int(0), plus(1).branch((is(gt(1)) -> plus(10)) `_,` (is(gt(2)) -> plus(20)) `_,` (__ -> int.plus(30))), int(31)),
+    testing(int(1, 2, 3), plus(0).branch((is(gt(1)) -> plus(10)) `_,` (is(gt(2)) -> plus(20)) `_,` (__ -> int.plus(30))), int(31, 12, 13, 32, 23, 33)),
+    testing(int(5), plus(0).branch(__ -> plus(1) `_,` __ -> plus(2) `_,` is(gt(10)) -> plus(6)), int(6, 7)),
+    testing(int(11), plus(0).branch(__ -> plus(1) `_,` __ -> plus(2) `_,` is(gt(10)) -> plus(6)), int(12, 13,17))),
   testSet("[branch] |-rec",
-    test(int.q(10), plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).is(gt(10))),
-    test(int(1), int.plus(0).branch((int + 0 -> int.plus(1)) `_|` (int -> int.plus(2))), int(2)),
-    test(int(1), int.plus(0).branch(int.q(0) -> plus(1) `_|` int.q(0) -> plus(2) `_|` int + 0 -> int.plus(3)), int(4)),
-    test(int(1), int.plus(0).branch(int + 0 -> plus(1).plus(1) `_|` int -> plus(3)), int(3)),
-    test(int(1), int.plus(0).branch(int.q(0) -> plus(1).plus(1) `_|` int -> plus(3).q(0)), zeroObj, compile = false),
-    test(int(1), int.plus(0).branch(int.q(0) -> plus(1).plus(1) `_|` int.plus(1).q(0) -> plus(3)), zeroObj, compile = false),
-    test(int(1, 2), int.q(2).plus(0).branch(int + 0 -> plus(1).plus(1) `_|` int -> plus(2)), int(3, 4)),
-    test(int(1, 2), int.q(2).plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).path(), strm(
+    testing(int.q(10), plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).is(gt(10)), int.q(0, 10) <= int.q(10).plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).is(gt(10))),
+    testing(int(1), int.plus(0).branch((int + 0 -> int.plus(1)) `_|` (int -> int.plus(2))), int(2)),
+    testing(int(1), int.plus(0).branch(int.q(0) -> plus(1) `_|` int.q(0) -> plus(2) `_|` int + 0 -> int.plus(3)), int(4)),
+    testing(int(1), int.plus(0).branch(int + 0 -> plus(1).plus(1) `_|` int -> plus(3)), int(3)),
+    testing(int(1), int.plus(0).branch(int.q(0) -> plus(1).plus(1) `_|` int -> plus(3).q(0)), zeroObj, compile = false),
+    testing(int(1), int.plus(0).branch(int.q(0) -> plus(1).plus(1) `_|` int.plus(1).q(0) -> plus(3)), zeroObj, compile = false),
+    testing(int(1, 2), int.q(2).plus(0).branch(int + 0 -> plus(1).plus(1) `_|` int -> plus(2)), int(3, 4)),
+    testing(int(1, 2), int.q(2).plus(0).branch(int + 0 -> plus(1) `_|` int -> plus(2)).path(), strm(
       lst(g = (";", List[Obj](int(1), PlusOp(0), 1, PlusOp(1), 2))),
       lst(g = (";", List[Obj](int(2), PlusOp(0), 2, PlusOp(1), 3))))))) {
 

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/CombineInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/CombineInstTest.scala
@@ -22,30 +22,22 @@
 
 package org.mmadt.processor.inst.branch
 
-import org.mmadt.TestUtil
 import org.mmadt.language.obj._
 import org.mmadt.language.obj.`type`.__
-import org.mmadt.language.obj.op.branch.CombineOp
+import org.mmadt.processor.inst.BaseInstTest
+import org.mmadt.processor.inst.TestSetUtil.testSet
 import org.mmadt.storage.StorageFactory._
-import org.scalatest.FunSuite
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
+import org.mmadt.processor.inst.TestSetUtil._
 
-class CombineInstTest extends FunSuite with TableDrivenPropertyChecks {
-  test("[combine] value, type, strm") {
-    val starts: TableFor3[Obj, Obj, Obj] =
-      new TableFor3[Obj, Obj, Obj](("lhs", "rhs", "result"),
-        (int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;` int.plus(2) `;` int.plus(3)), int(2) `;` 4 `;` 6),
-        (int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;` int.plus(2)), int(2) `;` 4 `;` 4),
-        (int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;`), int(2) `;` 3 `;` 4),
-        (int(1) `;` 2 `;` 3, lst.combine(lst), zeroObj `;`),
-        (int(1) `;` (int(2) `,` 3) `;` 4, lst.combine(int.plus(1) `;` lst[Int].>-.count() `;` int.plus(10)), int(2) `;` 2 `;` 14),
-        ///
-        (int(2) | 4, lst.combine(int.plus(2) `;` int.mult(10)), int(4) `;` 40),
-        (int(2) `;` 4, lst.combine(int.plus(2) `;` int.mult(10)), int(4) `;` 40),
-        (int(2) `;` 4, lst.combine(int.plus(2) | int.mult(10)), int(4) | zeroObj),
-        (int(4) | zeroObj, __.combine(int.plus(2) | int.mult(10)), int(6) | zeroObj)
-      )
-    forEvery(starts) { (lhs, rhs, result) => TestUtil.evaluate(lhs, rhs, result, CombineOp(rhs.via._2.arg0[Lst[Obj]]))
-    }
-  }
+class CombineInstTest extends BaseInstTest(
+  testSet("[combine] value, type, strm",
+    testing(int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;` int.plus(2) `;` int.plus(3)), int(2) `;` 4 `;` 6),
+    testing(int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;` int.plus(2)), int(2) `;` 4 `;` 4),
+    testing(int(1) `;` 2 `;` 3, lst.combine(int.plus(1) `;`), int(2) `;` 3 `;` 4),
+    testing(int(1) `;` 2 `;` 3, lst.combine(lst), zeroObj `;`),
+    testing(int(1) `;` (int(2) `,` 3) `;` 4, lst.combine(int.plus(1) `;` lst[Int].>-.count() `;` int.plus(10)), int(2) `;` 2 `;` 14),
+    testing(int(2) | 4, lst.combine(int.plus(2) `;` int.mult(10)), int(4) `;` 40),
+    testing(int(2) `;` 4, lst.combine(int.plus(2) `;` int.mult(10)), int(4) `;` 40),
+    testing(int(2) `;` 4, lst.combine(int.plus(2) | int.mult(10)), int(4) | zeroObj),
+    testing(int(4) | zeroObj, __.combine(int.plus(2) | int.mult(10)), int(6) | zeroObj))) {
 }

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/SplitInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/branch/SplitInstTest.scala
@@ -22,37 +22,23 @@
 
 package org.mmadt.processor.inst.branch
 
-import org.mmadt.language.obj.`type`.{Type, __}
+import org.mmadt.language.obj.`type`.__
 import org.mmadt.language.obj.op.trace.PathOp.VERTICES
-import org.mmadt.language.obj.{Int, Obj, Poly}
+import org.mmadt.language.obj.Int
+import org.mmadt.processor.inst.BaseInstTest
+import org.mmadt.processor.inst.TestSetUtil._
 import org.mmadt.storage.StorageFactory._
-import org.scalatest.FunSuite
-import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor3}
 
-class SplitInstTest extends FunSuite with TableDrivenPropertyChecks {
+class SplitInstTest extends BaseInstTest(
+  testSet("[split] value, type, strm",
+    testing(int(1), int.-<(int `;` int), int(1) `;` int(1)),
+    testing(int(1, 2, 3), int.q(3).-<(int.q(3) `;` int.q(3)), strm(List(int(1) `;` 1, int(2) `;` 2, int(3) `;` 3))),
+    testing(int(2), __.-<(int | str), int(2) | obj.q(qZero)),
+    testing(int(4).q(2), int.q(2).-<(int | int.is(__.gt(10))), (int(4) | obj.q(qZero)).q(2)),
+    testing(int(2).q(2), int.q(2).-<(int `;` int.is(__.gt(10))), (int(2) `;` obj.q(qZero)).q(2)),
+    testing(int(2), int.-<(int `;` int.is(__.gt(10))), int(2) `;` obj.q(qZero)))) {
 
-
-  test("[split] value, type, strm") {
-    val check: TableFor3[Obj, Poly[_ <: Obj], Obj] =
-      new TableFor3[Obj, Poly[_ <: Obj], Obj](("input", "type", "result"),
-        (int(1), int.-<(int `;` int), int(1) `;` int(1)),
-        (int(1, 2, 3), int.q(3).-<(int.q(3) `;` int.q(3)), strm(List(int(1) `;` 1, int(2) `;` 2, int(3) `;` 3))),
-        (int(2), __.-<(int | str), int(2) | obj.q(qZero)),
-        (int(4).q(2), int.q(2).-<(int | int.is(__.gt(10))), (int(4) | obj.q(qZero)).q(2)),
-        (int(2).q(2), int.q(2).-<(int `;` int.is(__.gt(10))), (int(2) `;` obj.q(qZero)).q(2)),
-        (int(2), int.-<(int `;` int.is(__.gt(10))), int(2) `;` obj.q(qZero)),
-        (int(2), int.-<(int.-<(int | int.is(__.gt(11))) | int.is(__.gt(10))), (int(2) | obj.q(qZero)) | obj.q(qZero)),
-      )
-    forEvery(check) { (input, atype, result) => {
-      // TestUtil.evaluate(input,atype,result)
-      assertResult(result)(input.compute(atype.asInstanceOf[Type[Obj]]))
-      assertResult(result)(input ==> atype.asInstanceOf[Type[Obj]])
-      assertResult(result)(input ==> atype)
-      assertResult(result)(input ==> (input.range ==> atype.asInstanceOf[Type[Obj]]))
-      assertResult(result)(input ==> (input.range ==> atype))
-    }
-    }
-  }
+    // testing(int(2), int.-<(int.-<(int | int.is(__.gt(11))) | int.is(__.gt(10))), (int(2) | obj.q(qZero)) | obj.q(qZero)) TODO: won't evaluate()
 
   test("lineage preservation (products)") {
     assertResult(int(321))(int(1) ==> int.plus(100).plus(200).split(int `,` bool).merge[Int].plus(20))

--- a/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
+++ b/jvm/machine/src/test/scala/org/mmadt/processor/inst/map/GtInstTest.scala
@@ -36,49 +36,49 @@ class GtInstTest extends BaseInstTest(
   /////////////////////////////////////////
   testSet("[gt] value, type, strm, anon combinations",
     comment("===INT"),
-    test(int(2), __.gt(1), btrue), // value * value = value
-    test(int(2).q(10), __.gt(1), btrue.q(10)), // value * value = value
-    test(int(2).q(10), __.gt(1).q(20), btrue.q(200)), // value * value = value
-    test(int(2), __.gt(int(1).q(10)), btrue), // value * value = value
-    test(int(2), __.gt(int), bfalse), // value * type = value
-    test(int(2), __.gt(__.mult(int)), bfalse), // value * anon = value
-    test(int, __.gt(int(2)), int.gt(int(2))), // type * value = type
-    test(int.q(10), __.gt(int(2)), int.q(10).gt(int(2))), // type * value = type
-    test(int, __.gt(int), int.gt(int)), // type * type = type
-    test(int(1, 2, 3), __.gt(2), bool(false, false, true)), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2).q(10)), bool(false, false, true)), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10))), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-    test(int(1, 2, 3), __.id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
-    test(int(1, 2, 3), __.gt(int), bool(false, false, false)), // strm * type = strm
-    test(int(1, 2, 3), __.gt(__.mult(int)), bool(false, false, false)), // strm * anon = strm
+    testing(int(2), __.gt(1), btrue), // value * value = value
+    testing(int(2).q(10), __.gt(1), btrue.q(10)), // value * value = value
+    testing(int(2).q(10), __.gt(1).q(20), btrue.q(200)), // value * value = value
+    testing(int(2), __.gt(int(1).q(10)), btrue), // value * value = value
+    testing(int(2), __.gt(int), bfalse), // value * type = value
+    testing(int(2), __.gt(__.mult(int)), bfalse), // value * anon = value
+    testing(int, __.gt(int(2)), int.gt(int(2))), // type * value = type
+    testing(int.q(10), __.gt(int(2)), int.q(10).gt(int(2))), // type * value = type
+    testing(int, __.gt(int), int.gt(int)), // type * type = type
+    testing(int(1, 2, 3), __.gt(2), bool(false, false, true)), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2).q(10)), bool(false, false, true)), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2)).q(10), bool(bfalse.q(20), btrue.q(10))), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2)).q(10).id(), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    testing(int(1, 2, 3), __.id().gt(int(2)).q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int(2)).id().q(10).id().q(5), bool(bfalse.q(50), bfalse.q(50), btrue.q(50))), // strm * value = strm
+    testing(int(1, 2, 3), __.gt(int), bool(false, false, false)), // strm * type = strm
+    testing(int(1, 2, 3), __.gt(__.mult(int)), bool(false, false, false)), // strm * anon = strm
     comment("===REAL"),
-    test(real(2.0), __.gt(1.0), btrue), // value * value = value
-    test(real(2.0), __.gt(real), bfalse), // value * type = value
-    test(real(2.0), __.gt(__.mult(real)), false), // value * anon = value
-    test(real, __.gt(real(2.0)), real.gt(2.0)), // type * value = type
-    test(real, __.gt(real), real.gt(real)), // type * type = type
-    test(real(1.0, 2.0, 3.0), __.gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
-    test(real(1.0, 2.0, 3.0), __.gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
-    test(real(1.0, 2.0, 3.0), __.gt(2.0), bool(false, false, true)), // strm * value = strm
-    test(real(1.0, 2.0, 3.0), __.gt(real), bool(false, false, false)), // strm * type = strm
-    test(real(1.0, 2.0, 3.0), __.gt(__.mult(real)), bool(false, false, false)), // strm * anon = strm
+    testing(real(2.0), __.gt(1.0), btrue), // value * value = value
+    testing(real(2.0), __.gt(real), bfalse), // value * type = value
+    testing(real(2.0), __.gt(__.mult(real)), false), // value * anon = value
+    testing(real, __.gt(real(2.0)), real.gt(2.0)), // type * value = type
+    testing(real, __.gt(real), real.gt(real)), // type * type = type
+    testing(real(1.0, 2.0, 3.0), __.gt(2.0).q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+    testing(real(1.0, 2.0, 3.0), __.gt(2.0).id().q(3), bool(bfalse.q(6), btrue.q(3))), // strm * value = strm
+    testing(real(1.0, 2.0, 3.0), __.gt(2.0), bool(false, false, true)), // strm * value = strm
+    testing(real(1.0, 2.0, 3.0), __.gt(real), bool(false, false, false)), // strm * type = strm
+    testing(real(1.0, 2.0, 3.0), __.gt(__.mult(real)), bool(false, false, false)), // strm * anon = strm
     comment("===STR"),
-    test(str("b"), __.gt("a"), btrue), // value * value = value
-    test(str("b").q(10), __.gt("a"), btrue.q(10)), // value * value = value
-    test(str("b").q(10), __.gt("a").q(20), btrue.q(200)), // value * value = value
-    test(str("b"), __.gt(str("a").q(10)), btrue), // value * value = value
-    test(str("b"), __.gt(str), bfalse), // value * type = value
-    test(str, __.gt("b"), str.gt("b")), // type * value = type
-    test(str.q(10), __.gt("b"), str.q(10).gt("b")), // type * value = type
-    test(str, __.gt(str), str.gt(str)), // type * type = type
-    test(str("a", "b", "c"), __.gt("b"), bool(false, false, true)), // strm * value = strm
-    test(str("a", "b", "c"), __.gt(str("b").q(10)), bool(false, false, true)), // strm * value = strm
-    test(str("a", "b", "c"), __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
-    test(str("a", "b", "c"), __.gt(str), bool(false, false, false)) // strm * type = strm
+    testing(str("b"), __.gt("a"), btrue), // value * value = value
+    testing(str("b").q(10), __.gt("a"), btrue.q(10)), // value * value = value
+    testing(str("b").q(10), __.gt("a").q(20), btrue.q(200)), // value * value = value
+    testing(str("b"), __.gt(str("a").q(10)), btrue), // value * value = value
+    testing(str("b"), __.gt(str), bfalse), // value * type = value
+    testing(str, __.gt("b"), str.gt("b")), // type * value = type
+    testing(str.q(10), __.gt("b"), str.q(10).gt("b")), // type * value = type
+    testing(str, __.gt(str), str.gt(str)), // type * type = type
+    testing(str("a", "b", "c"), __.gt("b"), bool(false, false, true)), // strm * value = strm
+    testing(str("a", "b", "c"), __.gt(str("b").q(10)), bool(false, false, true)), // strm * value = strm
+    testing(str("a", "b", "c"), __.gt("b").q(10), bool(bfalse.q(10), bfalse.q(10), btrue.q(10))), // strm * value = strm
+    testing(str("a", "b", "c"), __.gt(str), bool(false, false, false)) // strm * type = strm
   )) {
 
   test("[gt] exceptions") {


### PR DESCRIPTION
Renamed BaseInstTest.test() to testing() so that it didn't look confusing with test() from scalatest.